### PR TITLE
feature: make the commit url configurable via an additional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ $ npm i changelog-maker -g
 
 ## Usage
 
-**`changelog-maker [--simple] [--group] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
+**`changelog-maker [--simple] [--group] [--commit-url=<url/with/{sha}>] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
 
 `github-user` and `github-project` should point to the GitHub repository that can be used to find the `PR-URL` data if just an issue number is provided and will also impact how the PR-URL issue numbers are displayed
 
  * `--simple`:          print a simple form, without additional Markdown cruft
  * `--group`:           reorder commits so that they are listed in groups where the `xyz:` prefix of the commit message defines the group. Commits are listed in original order _within_ group.
+ * `--commit-url`: pass in a url template which will be used to generate commit URLs for a respository not hosted in Github. `{sha}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{sha}` 
  * `--start-ref=<ref>`: use the given git `<ref>` as a starting point rather than the _last tag_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name. If you specify a `--start-ref` argument the commit log will not be pruned so that version commits and `working on <version>` commits are left in the list.
  * `--end-ref=<ref>`:   use the given git `<ref>` as a end-point rather than the _now_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name.
  * `--filter-release`:  exclude Node-style release commits from the list. e.g. "Working on v1.0.0" or "2015-10-21 Version 2.0.0" and also "npm version X" style commits containing _only_ an `x.y.z` semver designator.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ $ npm i changelog-maker -g
 
 ## Usage
 
-**`changelog-maker [--simple] [--group] [--commit-url=<url/with/{sha}>] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
+**`changelog-maker [--simple] [--group] [--commit-url=<url/with/{ref}>] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
 
 `github-user` and `github-project` should point to the GitHub repository that can be used to find the `PR-URL` data if just an issue number is provided and will also impact how the PR-URL issue numbers are displayed
 
  * `--simple`:          print a simple form, without additional Markdown cruft
  * `--group`:           reorder commits so that they are listed in groups where the `xyz:` prefix of the commit message defines the group. Commits are listed in original order _within_ group.
- * `--commit-url`: pass in a url template which will be used to generate commit URLs for a respository not hosted in Github. `{sha}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{sha}` 
+ * `--commit-url`: pass in a url template which will be used to generate commit URLs for a repository not hosted in Github. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}` 
  * `--start-ref=<ref>`: use the given git `<ref>` as a starting point rather than the _last tag_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name. If you specify a `--start-ref` argument the commit log will not be pruned so that version commits and `working on <version>` commits are left in the list.
  * `--end-ref=<ref>`:   use the given git `<ref>` as a end-point rather than the _now_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name.
  * `--filter-release`:  exclude Node-style release commits from the list. e.g. "Working on v1.0.0" or "2015-10-21 Version 2.0.0" and also "npm version X" style commits containing _only_ an `x.y.z` semver designator.

--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -19,6 +19,7 @@ const bl             = require('bl')
     , quiet          = argv.quiet || argv.q
     , simple         = argv.simple || argv.s
     , help           = argv.h || argv.help 
+    , commitUrl      = argv["commit-url"]
 
     , pkg            = require('./package.json')
     , debug          = require('debug')(pkg.name)
@@ -115,7 +116,7 @@ function onCommitList (err, list) {
       list = groupCommits(list)
 
     list = list.map(function (commit) {
-      return commitToOutput(commit, simple, ghId)
+      return commitToOutput(commit, simple, ghId, commitUrl)
     })
 
     if (!quiet)

--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -52,10 +52,10 @@ function commitToOutput (commit, simple, ghId, commitUrl) {
     , prUrlMatch  = commit.prUrl && commit.prUrl.match(/^https?:\/\/.+\/([^\/]+\/[^\/]+)\/\w+\/\d+$/i)
     , urlHash     = '#'+commit.ghIssue || commit.prUrl
     , ghUrl       = ghId.user + '/' + ghId.name
-    , shaShort    = commit.sha.substr(0, 10)
+    , ref         = commit.sha.substr(0, 10)
 
   data.sha     = commit.sha
-  data.shaUrl  = commitUrl ? commitUrl.replace("{sha}", shaShort) : 'https://github.com/' + ghUrl + '/commit/' + shaShort
+  data.shaUrl  = commitUrl ? commitUrl.replace("{ref}", ref) : 'https://github.com/' + ghUrl + '/commit/' + ref
   data.semver  = commit.labels && commit.labels.filter(function (l) { return l.indexOf('semver') > -1 }) || false
   data.revert  = reverts.isRevert(commit.summary)
   data.group   = groups.toGroups(commit.summary)

--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -47,14 +47,15 @@ function toStringMarkdown (data) {
 }
 
 
-function commitToOutput (commit, simple, ghId) {
+function commitToOutput (commit, simple, ghId, commitUrl) {
   var data        = {}
     , prUrlMatch  = commit.prUrl && commit.prUrl.match(/^https?:\/\/.+\/([^\/]+\/[^\/]+)\/\w+\/\d+$/i)
     , urlHash     = '#'+commit.ghIssue || commit.prUrl
     , ghUrl       = ghId.user + '/' + ghId.name
+    , shaShort    = commit.sha.substr(0, 10)
 
   data.sha     = commit.sha
-  data.shaUrl  = 'https://github.com/' + ghUrl + '/commit/' + commit.sha.substr(0,10)
+  data.shaUrl  = commitUrl ? commitUrl.replace("{sha}", shaShort) : 'https://github.com/' + ghUrl + '/commit/' + shaShort
   data.semver  = commit.labels && commit.labels.filter(function (l) { return l.indexOf('semver') > -1 }) || false
   data.revert  = reverts.isRevert(commit.summary)
   data.group   = groups.toGroups(commit.summary)


### PR DESCRIPTION
Fixes #32 

Allows you to pass `--commit-url` as a template string for specifying commit URLs for repositories that aren't hosted on Github. `{sha}` serves as the part of the string which will be replaced.