### PR TITLE
testing, linting, minor fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ npm i changelog-maker -g
 
  * `--simple`:          print a simple form, without additional Markdown cruft
  * `--group`:           reorder commits so that they are listed in groups where the `xyz:` prefix of the commit message defines the group. Commits are listed in original order _within_ group.
- * `--commit-url`: pass in a url template which will be used to generate commit URLs for a repository not hosted in Github. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}` 
+ * `--commit-url`: pass in a url template which will be used to generate commit URLs for a repository not hosted in Github. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}`
  * `--start-ref=<ref>`: use the given git `<ref>` as a starting point rather than the _last tag_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name. If you specify a `--start-ref` argument the commit log will not be pruned so that version commits and `working on <version>` commits are left in the list.
  * `--end-ref=<ref>`:   use the given git `<ref>` as a end-point rather than the _now_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name.
  * `--filter-release`:  exclude Node-style release commits from the list. e.g. "Working on v1.0.0" or "2015-10-21 Version 2.0.0" and also "npm version X" style commits containing _only_ an `x.y.z` semver designator.

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ $ npm i changelog-maker -g
 
 ## Usage
 
-**`changelog-maker [--simple] [--group] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
+**`changelog-maker [--simple] [--group] [--commit-url=<url/with/{ref}>] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
 
 `github-user` and `github-project` should point to the GitHub repository that can be used to find the `PR-URL` data if just an issue number is provided and will also impact how the PR-URL issue numbers are displayed
 
  * `--simple`:          print a simple form, without additional Markdown cruft
  * `--group`:           reorder commits so that they are listed in groups where the `xyz:` prefix of the commit message defines the group. Commits are listed in original order _within_ group.
+ * `--commit-url`: pass in a url template which will be used to generate commit URLs for a repository not hosted in Github. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}` 
  * `--start-ref=<ref>`: use the given git `<ref>` as a starting point rather than the _last tag_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name. If you specify a `--start-ref` argument the commit log will not be pruned so that version commits and `working on <version>` commits are left in the list.
  * `--end-ref=<ref>`:   use the given git `<ref>` as a end-point rather than the _now_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name.
  * `--filter-release`:  exclude Node-style release commits from the list. e.g. "Working on v1.0.0" or "2015-10-21 Version 2.0.0" and also "npm version X" style commits containing _only_ an `x.y.z` semver designator.

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ $ npm i changelog-maker -g
 
  * `--simple`:          print a simple form, without additional Markdown cruft
  * `--group`:           reorder commits so that they are listed in groups where the `xyz:` prefix of the commit message defines the group. Commits are listed in original order _within_ group.
- * `--commit-url`: pass in a url template which will be used to generate commit URLs for a repository not hosted in Github. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}`
+ * `--commit-url`:      pass in a url template which will be used to generate commit URLs for a repository not hosted in Github. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}`
  * `--start-ref=<ref>`: use the given git `<ref>` as a starting point rather than the _last tag_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name. If you specify a `--start-ref` argument the commit log will not be pruned so that version commits and `working on <version>` commits are left in the list.
  * `--end-ref=<ref>`:   use the given git `<ref>` as a end-point rather than the _now_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name.
  * `--filter-release`:  exclude Node-style release commits from the list. e.g. "Working on v1.0.0" or "2015-10-21 Version 2.0.0" and also "npm version X" style commits containing _only_ an `x.y.z` semver designator.
- * `--quiet` or `-q`:     do not print to `process.stdout`
- * `--all` or `-a`:       process all commits since beginning, instead of last tag.
- * `--help` or `-h`:      show usage and help.
+ * `--quiet` or `-q`:   do not print to `process.stdout`
+ * `--all` or `-a`:     process all commits since beginning, instead of last tag.
+ * `--help` or `-h`:    show usage and help.
 
 ## License
 

--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -19,6 +19,7 @@ const bl             = require('bl')
     , quiet          = argv.quiet || argv.q
     , simple         = argv.simple || argv.s
     , help           = argv.h || argv.help 
+    , commitUrl      = argv["commit-url"]
 
     , pkg            = require('./package.json')
     , debug          = require('debug')(pkg.name)
@@ -115,7 +116,7 @@ function onCommitList (err, list) {
       list = groupCommits(list)
 
     list = list.map(function (commit) {
-      return commitToOutput(commit, simple, ghId)
+      return commitToOutput(commit, simple, ghId, commitUrl)
     })
 
     if (!quiet)

--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -4,7 +4,7 @@ const split2 = require('split2')
 const list = require('list-stream')
 const fs = require('fs')
 const path = require('path')
-const chalk = require('chalk')
+const stripAnsi = require('strip-ansi')
 const pkgtoId = require('pkg-to-id')
 const commitStream = require('commit-stream')
 const gitexec = require('gitexec')
@@ -93,7 +93,7 @@ function printCommits (list) {
   var out = list.join('\n') + '\n'
 
   if (!process.stdout.isTTY) {
-    out = chalk.stripColor(out)
+    out = stripAnsi(out)
   }
 
   process.stdout.write(out)

--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -19,14 +19,14 @@ const argv = require('minimist')(process.argv.slice(2))
 const quiet = argv.quiet || argv.q
 const simple = argv.simple || argv.s
 const help = argv.h || argv.help
-const commitUrl = argv['commit-url']
+const commitUrl = argv['commit-url'] || 'https://github.com/{ghUser}/{ghRepo}/commit/{ref}'
 const pkgFile = path.join(process.cwd(), 'package.json')
 const pkgData = fs.existsSync(pkgFile) ? require(pkgFile) : {}
 const pkgId = pkgtoId(pkgData)
 
 const ghId = {
   user: argv._[0] || pkgId.user || 'nodejs',
-  name: argv._[1] || (pkgId.name && stripScope(pkgId.name)) || 'node'
+  repo: argv._[1] || (pkgId.name && stripScope(pkgId.name)) || 'node'
 }
 const gitcmd = 'git log --pretty=full --since="{{sincecmd}}" --until="{{untilcmd}}"'
 const commitdatecmd = '$(git show -s --format=%cd `{{refcmd}}`)'
@@ -139,5 +139,5 @@ debug('%s', _gitcmd)
 
 gitexec.exec(process.cwd(), _gitcmd)
   .pipe(split2())
-  .pipe(commitStream(ghId.user, ghId.name))
+  .pipe(commitStream(ghId.user, ghId.repo))
   .pipe(list.obj(onCommitList))

--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -1,42 +1,38 @@
 #!/usr/bin/env node
 
-const bl             = require('bl')
-    , split2         = require('split2')
-    , list           = require('list-stream')
-    , fs             = require('fs')
-    , path           = require('path')
-    , chalk          = require('chalk')
-    , pkgtoId        = require('pkg-to-id')
-    , commitStream   = require('commit-stream')
-    , gitexec        = require('gitexec')
-    , commitToOutput = require('./commit-to-output')
-    , groupCommits   = require('./group-commits')
-    , collectCommitLabels = require('./collect-commit-labels')
-    , isReleaseCommit = require('./groups').isReleaseCommit
+const split2 = require('split2')
+const list = require('list-stream')
+const fs = require('fs')
+const path = require('path')
+const chalk = require('chalk')
+const pkgtoId = require('pkg-to-id')
+const commitStream = require('commit-stream')
+const gitexec = require('gitexec')
+const commitToOutput = require('./commit-to-output')
+const groupCommits = require('./group-commits')
+const collectCommitLabels = require('./collect-commit-labels')
+const isReleaseCommit = require('./groups').isReleaseCommit
+const pkg = require('./package.json')
+const debug = require('debug')(pkg.name)
+const argv = require('minimist')(process.argv.slice(2))
 
-    , argv           = require('minimist')(process.argv.slice(2))
+const quiet = argv.quiet || argv.q
+const simple = argv.simple || argv.s
+const help = argv.h || argv.help
+const commitUrl = argv['commit-url']
+const pkgFile = path.join(process.cwd(), 'package.json')
+const pkgData = fs.existsSync(pkgFile) ? require(pkgFile) : {}
+const pkgId = pkgtoId(pkgData)
 
-    , quiet          = argv.quiet || argv.q
-    , simple         = argv.simple || argv.s
-    , help           = argv.h || argv.help 
-    , commitUrl      = argv["commit-url"]
-
-    , pkg            = require('./package.json')
-    , debug          = require('debug')(pkg.name)
-    , pkgFile        = path.join(process.cwd(), 'package.json')
-    , pkgData        = fs.existsSync(pkgFile) ? require(pkgFile) : {}
-    , pkgId          = pkgtoId(pkgData)
-
-    , ghId           = {
-          user: argv._[0] || pkgId.user || 'nodejs'
-        , name: argv._[1] || (pkgId.name && stripScope(pkgId.name)) || 'node'
-      }
-
-const gitcmd         = 'git log --pretty=full --since="{{sincecmd}}" --until="{{untilcmd}}"'
-    , commitdatecmd  = '$(git show -s --format=%cd `{{refcmd}}`)'
-    , untilcmd       = ''
-    , refcmd         = argv.a || argv.all ? 'git rev-list --max-parents=0 HEAD' : 'git rev-list --max-count=1 {{ref}}'
-    , defaultRef     = '--tags=v*.*.* 2> /dev/null ' +
+const ghId = {
+  user: argv._[0] || pkgId.user || 'nodejs',
+  name: argv._[1] || (pkgId.name && stripScope(pkgId.name)) || 'node'
+}
+const gitcmd = 'git log --pretty=full --since="{{sincecmd}}" --until="{{untilcmd}}"'
+const commitdatecmd = '$(git show -s --format=%cd `{{refcmd}}`)'
+const untilcmd = ''
+const refcmd = argv.a || argv.all ? 'git rev-list --max-parents=0 HEAD' : 'git rev-list --max-count=1 {{ref}}'
+const defaultRef = '--tags=v*.*.* 2> /dev/null ' +
         '|| git rev-list --max-count=1 --tags=*.*.* 2> /dev/null ' +
         '|| git rev-list --max-count=1 HEAD'
 
@@ -45,7 +41,7 @@ debug(ghId)
 if (help) {
   showUsage()
   process.exit(0)
-} 
+}
 
 function showUsage () {
   var usage = fs.readFileSync(path.join(__dirname, 'README.md'), 'utf8')
@@ -57,7 +53,7 @@ function showUsage () {
       .replace(/`/g, '')
   }
   process.stdout.write(usage)
-} 
+}
 
 function stripScope (name) {
   return name[0] === '@' && name.indexOf('/') > 0 ? name.split('/')[1] : name
@@ -70,66 +66,70 @@ function replace (s, m) {
   return s
 }
 
-
 function organiseCommits (list) {
   if (argv['start-ref'] || argv.a || argv.all) {
-    if (argv['filter-release'])
+    if (argv['filter-release']) {
       list = list.filter(function (commit) { return !isReleaseCommit(commit.summary) })
+    }
     return list
   }
 
   // filter commits to those _before_ 'working on ...'
   var started = false
   return list.filter(function (commit) {
-    if (started)
+    if (started) {
       return false
+    }
 
-    if (isReleaseCommit(commit.summary))
+    if (isReleaseCommit(commit.summary)) {
       started = true
+    }
 
     return !started
   })
 }
 
-
 function printCommits (list) {
   var out = list.join('\n') + '\n'
 
-  if (!process.stdout.isTTY)
+  if (!process.stdout.isTTY) {
     out = chalk.stripColor(out)
+  }
 
   process.stdout.write(out)
 }
 
-
 function onCommitList (err, list) {
-  if (err)
+  if (err) {
     throw err
+  }
 
   list = organiseCommits(list)
 
   collectCommitLabels(list, function (err) {
-    if (err)
+    if (err) {
       throw err
+    }
 
-    if (argv.group)
+    if (argv.group) {
       list = groupCommits(list)
+    }
 
     list = list.map(function (commit) {
       return commitToOutput(commit, simple, ghId, commitUrl)
     })
 
-    if (!quiet)
+    if (!quiet) {
       printCommits(list)
+    }
   })
 }
 
-
-var _startrefcmd = replace(refcmd, { ref: argv['start-ref'] || defaultRef })
-  , _endrefcmd   = argv['end-ref'] && replace(refcmd, { ref: argv['end-ref'] })
-  , _sincecmd    = replace(commitdatecmd, { refcmd: _startrefcmd })
-  , _untilcmd    = argv['end-ref'] ? replace(commitdatecmd, { refcmd: _endrefcmd }) : untilcmd
-  , _gitcmd      = replace(gitcmd, { sincecmd: _sincecmd, untilcmd: _untilcmd })
+let _startrefcmd = replace(refcmd, { ref: argv['start-ref'] || defaultRef })
+let _endrefcmd = argv['end-ref'] && replace(refcmd, { ref: argv['end-ref'] })
+let _sincecmd = replace(commitdatecmd, { refcmd: _startrefcmd })
+let _untilcmd = argv['end-ref'] ? replace(commitdatecmd, { refcmd: _endrefcmd }) : untilcmd
+let _gitcmd = replace(gitcmd, { sincecmd: _sincecmd, untilcmd: _untilcmd })
 
 debug('%s', _startrefcmd)
 debug('%s', _endrefcmd)

--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -1,40 +1,43 @@
-const ghauth         = require('ghauth')
-    , ghissues       = require('ghissues')
-    , async          = require('async')
+const ghauth = require('ghauth')
+const ghissues = require('ghissues')
+const async = require('async')
 
-    , authOptions    = {
-          configName : 'changelog-maker'
-        , scopes     : ['repo']
-      }
-
+const authOptions = {
+  configName: 'changelog-maker',
+  scopes: ['repo']
+}
 
 function collectCommitLabels (list, callback) {
-  var sublist = list.filter(function (commit) {
-    return typeof commit.ghIssue == 'number' && commit.ghUser && commit.ghProject
+  let sublist = list.filter(function (commit) {
+    return typeof commit.ghIssue === 'number' && commit.ghUser && commit.ghProject
   })
 
-  if (!sublist.length)
+  if (!sublist.length) {
     return setImmediate(callback)
+  }
 
   ghauth(authOptions, function (err, authData) {
     const cache = {}
 
-    if (err)
+    if (err) {
       return callback(err)
-    var q = async.queue(function (commit, next) {
+    }
+    let q = async.queue(function (commit, next) {
       function onFetch (err, issue) {
         if (err) {
-          console.error('Error fetching issue #%s: %s', commit.ghIssue, err.message );
+          console.error('Error fetching issue #%s: %s', commit.ghIssue, err.message)
           return next()
         }
 
-        if (issue.labels)
+        if (issue.labels) {
           commit.labels = issue.labels.map(function (label) { return label.name })
+        }
         next()
       }
 
-      if (commit.ghUser == 'iojs')
-        commit.ghUser = 'nodejs' // forcably rewrite as the GH API doesn't do it for us
+      if (commit.ghUser === 'iojs') {
+        commit.ghUser = 'nodejs'// forcably rewrite as the GH API doesn't do it for us
+      }
 
       // To prevent multiple simultaneous requests for the same issue
       // from hitting the network at the same time, immediately assign a Promise
@@ -52,6 +55,5 @@ function collectCommitLabels (list, callback) {
     q.push(sublist)
   })
 }
-
 
 module.exports = collectCommitLabels

--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -17,6 +17,7 @@ function toStringSimple (data) {
   s += data.revert ? '" ' : ' '
   s += data.author ? '(' + data.author + ') ' : ''
   s += data.pr ? data.prUrl : ''
+  s = s.trim()
 
   return (data.semver && data.semver.length)
     ? chalk.green(chalk.bold(s))
@@ -48,17 +49,16 @@ function commitToOutput (commit, simple, ghId, commitUrl) {
   let data = {}
   let prUrlMatch = commit.prUrl && commit.prUrl.match(/^https?:\/\/.+\/([^/]+\/[^/]+)\/\w+\/\d+$/i)
   let urlHash = '#' + commit.ghIssue || commit.prUrl
-  let ghUrl = ghId.user + '/' + ghId.name
   let ref = commit.sha.substr(0, 10)
 
   data.sha = commit.sha
-  data.shaUrl = commitUrl ? commitUrl.replace('{ref}', ref) : 'https://github.com/' + ghUrl + '/commit/' + ref
+  data.shaUrl = commitUrl.replace(/\{ghUser\}/g, ghId.user).replace(/\{ghRepo\}/g, ghId.repo).replace(/\{ref\}/g, ref)
   data.semver = commit.labels && commit.labels.filter((l) => l.indexOf('semver') > -1)
   data.revert = reverts.isRevert(commit.summary)
   data.group = groups.toGroups(commit.summary)
   data.summary = groups.cleanSummary(reverts.cleanSummary(commit.summary))
   data.author = (commit.author && commit.author.name) || ''
-  data.pr = prUrlMatch && ((prUrlMatch[1] !== ghUrl ? prUrlMatch[1] : '') + urlHash)
+  data.pr = prUrlMatch && ((prUrlMatch[1] !== `${ghId.user}/${ghId.repo}` ? prUrlMatch[1] : '') + urlHash)
   data.prUrl = prUrlMatch && commit.prUrl
 
   return (simple ? toStringSimple : toStringMarkdown)(data)

--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -1,16 +1,14 @@
-const chalk   = require('chalk')
-    , reverts = require('./reverts')
-    , groups  = require('./groups')
-
+const chalk = require('chalk')
+const reverts = require('./reverts')
+const groups = require('./groups')
 
 function cleanMarkdown (txt) {
   // escape _~*\[]<>
-  return txt.replace(/([_~*\\\[\]<>])/g, '\\$1')
+  return txt.replace(/([_~*\\[\]<>])/g, '\\$1')
 }
 
-
 function toStringSimple (data) {
-  var s = ''
+  let s = ''
   s += '* [' + data.sha.substr(0, 10) + '] - '
   s += (data.semver || []).length ? '(' + data.semver.join(', ').toUpperCase() + ') ' : ''
   s += data.revert ? 'Revert "' : ''
@@ -21,15 +19,14 @@ function toStringSimple (data) {
   s += data.pr ? data.prUrl : ''
 
   return data.semver.length
-      ? chalk.green(chalk.bold(s))
-      : data.group == 'doc'
-        ? chalk.grey(s)
-        : s
+    ? chalk.green(chalk.bold(s))
+    : data.group === 'doc'
+      ? chalk.grey(s)
+      : s
 }
 
-
 function toStringMarkdown (data) {
-  var s = ''
+  let s = ''
   s += '* [[`' + data.sha.substr(0, 10) + '`](' + data.shaUrl + ')] - '
   s += (data.semver || []).length ? '**(' + data.semver.join(', ').toUpperCase() + ')** ' : ''
   s += data.revert ? '***Revert*** "' : ''
@@ -39,33 +36,31 @@ function toStringMarkdown (data) {
   s += data.author ? '(' + data.author + ') ' : ''
   s += data.pr ? '[' + data.pr + '](' + data.prUrl + ')' : ''
 
-  return data.semver.length
-      ? chalk.green(chalk.bold(s))
-      : data.group == 'doc'
-        ? chalk.grey(s)
-        : s
+  return (data.semver && data.semver.length)
+    ? chalk.green(chalk.bold(s))
+    : data.group === 'doc'
+      ? chalk.grey(s)
+      : s
 }
 
-
 function commitToOutput (commit, simple, ghId, commitUrl) {
-  var data        = {}
-    , prUrlMatch  = commit.prUrl && commit.prUrl.match(/^https?:\/\/.+\/([^\/]+\/[^\/]+)\/\w+\/\d+$/i)
-    , urlHash     = '#'+commit.ghIssue || commit.prUrl
-    , ghUrl       = ghId.user + '/' + ghId.name
-    , ref         = commit.sha.substr(0, 10)
+  let data = {}
+  let prUrlMatch = commit.prUrl && commit.prUrl.match(/^https?:\/\/.+\/([^/]+\/[^/]+)\/\w+\/\d+$/i)
+  let urlHash = '#' + commit.ghIssue || commit.prUrl
+  let ghUrl = ghId.user + '/' + ghId.name
+  let ref = commit.sha.substr(0, 10)
 
-  data.sha     = commit.sha
-  data.shaUrl  = commitUrl ? commitUrl.replace("{ref}", ref) : 'https://github.com/' + ghUrl + '/commit/' + ref
-  data.semver  = commit.labels && commit.labels.filter(function (l) { return l.indexOf('semver') > -1 }) || false
-  data.revert  = reverts.isRevert(commit.summary)
-  data.group   = groups.toGroups(commit.summary)
+  data.sha = commit.sha
+  data.shaUrl = commitUrl ? commitUrl.replace('{ref}', ref) : 'https://github.com/' + ghUrl + '/commit/' + ref
+  data.semver = commit.labels && commit.labels.filter((l) => l.indexOf('semver') > -1)
+  data.revert = reverts.isRevert(commit.summary)
+  data.group = groups.toGroups(commit.summary)
   data.summary = groups.cleanSummary(reverts.cleanSummary(commit.summary))
-  data.author  = (commit.author && commit.author.name) || ''
-  data.pr      = prUrlMatch && ((prUrlMatch[1] != ghUrl ? prUrlMatch[1] : '') + urlHash)
-  data.prUrl   = prUrlMatch && commit.prUrl
+  data.author = (commit.author && commit.author.name) || ''
+  data.pr = prUrlMatch && ((prUrlMatch[1] !== ghUrl ? prUrlMatch[1] : '') + urlHash)
+  data.prUrl = prUrlMatch && commit.prUrl
 
   return (simple ? toStringSimple : toStringMarkdown)(data)
 }
-
 
 module.exports = commitToOutput

--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -47,14 +47,15 @@ function toStringMarkdown (data) {
 }
 
 
-function commitToOutput (commit, simple, ghId) {
+function commitToOutput (commit, simple, ghId, commitUrl) {
   var data        = {}
     , prUrlMatch  = commit.prUrl && commit.prUrl.match(/^https?:\/\/.+\/([^\/]+\/[^\/]+)\/\w+\/\d+$/i)
     , urlHash     = '#'+commit.ghIssue || commit.prUrl
     , ghUrl       = ghId.user + '/' + ghId.name
+    , ref         = commit.sha.substr(0, 10)
 
   data.sha     = commit.sha
-  data.shaUrl  = 'https://github.com/' + ghUrl + '/commit/' + commit.sha.substr(0,10)
+  data.shaUrl  = commitUrl ? commitUrl.replace("{ref}", ref) : 'https://github.com/' + ghUrl + '/commit/' + ref
   data.semver  = commit.labels && commit.labels.filter(function (l) { return l.indexOf('semver') > -1 }) || false
   data.revert  = reverts.isRevert(commit.summary)
   data.group   = groups.toGroups(commit.summary)

--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -18,7 +18,7 @@ function toStringSimple (data) {
   s += data.author ? '(' + data.author + ') ' : ''
   s += data.pr ? data.prUrl : ''
 
-  return data.semver.length
+  return (data.semver && data.semver.length)
     ? chalk.green(chalk.bold(s))
     : data.group === 'doc'
       ? chalk.grey(s)
@@ -35,6 +35,7 @@ function toStringMarkdown (data) {
   s += data.revert ? '" ' : ' '
   s += data.author ? '(' + data.author + ') ' : ''
   s += data.pr ? '[' + data.pr + '](' + data.prUrl + ')' : ''
+  s = s.trim()
 
   return (data.semver && data.semver.length)
     ? chalk.green(chalk.bold(s))

--- a/group-commits.js
+++ b/group-commits.js
@@ -1,11 +1,11 @@
 const toGroups = require('./groups').toGroups
 
-
 function groupCommits (list) {
   var groupList = list.reduce(function (groupList, commit) {
     var group = toGroups(commit.summary) || '*'
-    if (!groupList[group])
+    if (!groupList[group]) {
       groupList[group] = []
+    }
     groupList[group].push(commit)
     return groupList
   }, {})
@@ -14,6 +14,5 @@ function groupCommits (list) {
     return p.concat(groupList[group])
   }, [])
 }
-
 
 module.exports = groupCommits

--- a/groups.js
+++ b/groups.js
@@ -1,18 +1,15 @@
-const groupRe = /^((:?\w|\-|,|, )+):\s*/i
-    , reverts = require('./reverts')
-
+const groupRe = /^((:?\w|-|,|, )+):\s*/i
+const reverts = require('./reverts')
 
 function toGroups (summary) {
   summary = reverts.cleanSummary(summary)
-  var m = summary.match(groupRe)
+  let m = summary.match(groupRe)
   return (m && m[1]) || ''
 }
-
 
 function cleanSummary (summary) {
   return (summary || '').replace(groupRe, '')
 }
-
 
 /*
 
@@ -30,25 +27,25 @@ doesn't cover false positives though
 */
 
 function isReleaseCommit (summary) {
-  return /^Working on v?\d{1,2}\.\d{1,3}\.\d{1,3}$/.test(summary)
-         || /^\d{4}-\d{2}-\d{2},? (Node\.js|Version) v?\d{1,2}\.\d{1,3}\.\d{1,3} (["'][A-Za-z ]+["'] )?\((Current|Stable|LTS|Maintenance)\)/.test(summary)
-         || /^\d{4}-\d{2}-\d{2},? io.js v\d{1,2}\.\d{1,3}\.\d{1,3} Release/.test(summary)
-         || /^\d+\.\d+\.\d+$/.test(summary) // `npm version X` style commit
+  return /^Working on v?\d{1,2}\.\d{1,3}\.\d{1,3}$/.test(summary) ||
+    /^\d{4}-\d{2}-\d{2},? (Node\.js|Version) v?\d{1,2}\.\d{1,3}\.\d{1,3} (["'][A-Za-z ]+["'] )?\((Current|Stable|LTS|Maintenance)\)/.test(summary) ||
+    /^\d{4}-\d{2}-\d{2},? io.js v\d{1,2}\.\d{1,3}\.\d{1,3} Release/.test(summary) ||
+    /^\d+\.\d+\.\d+$/.test(summary) // `npm version X` style commit
 }
 
-
-module.exports.toGroups        = toGroups
-module.exports.cleanSummary    = cleanSummary
+module.exports.toGroups = toGroups
+module.exports.cleanSummary = cleanSummary
 module.exports.isReleaseCommit = isReleaseCommit
 
-
-if (require.main == module) {
+if (require.main === module) {
   console.log(`Running tests on lines in ${process.argv[2]}...`)
-  var failures = require('fs').readFileSync(process.argv[2], 'utf8').split('\n').filter(Boolean).filter((summary) => {
+  let failures = require('fs').readFileSync(process.argv[2], 'utf8').split('\n').filter(Boolean).filter((summary) => {
     return !isReleaseCommit(summary)
   })
-  if (!failures.length)
-    return console.log('All good, no failures!')
-  console.log('Failed on the following commit summaries:')
-  console.log(failures.join('\n'))
+  if (!failures.length) {
+    console.log('All good, no failures!')
+  } else {
+    console.log('Failed on the following commit summaries:')
+    console.log(failures.join('\n'))
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/rvagg/changelog-maker.git"
+    "url": "https://github.com/nodejs/changelog-maker.git"
   },
   "preferGlobal": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "async": "~2.6.1",
-    "bl": "~2.1.2",
     "chalk": "~2.4.1",
     "commit-stream": "~1.1.0",
     "debug": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -9,18 +9,18 @@
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "MIT",
   "dependencies": {
-    "async": "~2.6.0",
-    "bl": "~1.2.1",
-    "chalk": "~1.1.3",
+    "async": "~2.6.1",
+    "bl": "~2.1.2",
+    "chalk": "~2.4.1",
     "commit-stream": "~1.1.0",
-    "debug": "~3.1.0",
+    "debug": "~4.1.0",
     "ghauth": "~3.2.1",
     "ghissues": "~1.1.3",
     "gitexec": "~1.0.0",
     "list-stream": "~1.0.1",
     "minimist": "~1.2.0",
     "pkg-to-id": "~0.0.3",
-    "split2": "~2.2.0"
+    "split2": "~3.0.0"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,10 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "lint": "jshint ./*js"
+    "lint": "standard"
+  },
+  "devDependencies": {
+    "standard": "~12.0.1",
+    "tape": "~4.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "list-stream": "~1.0.1",
     "minimist": "~1.2.0",
     "pkg-to-id": "~0.0.3",
-    "split2": "~3.0.0"
+    "split2": "~3.0.0",
+    "strip-ansi": "~5.0.0"
   },
   "repository": {
     "type": "git",
@@ -27,7 +28,8 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "lint": "standard"
+    "lint": "standard",
+    "test": "standard && tape test.js"
   },
   "devDependencies": {
     "standard": "~12.0.1",

--- a/reverts.js
+++ b/reverts.js
@@ -1,18 +1,14 @@
 const revertRe = /^revert\s+"?/i
 
-
 function isRevert (summary) {
   return summary && revertRe.test(summary)
 }
 
-
 function cleanSummary (summary) {
   summary = summary || ''
-  if (!isRevert(summary))
-    return summary
+  if (!isRevert(summary)) { return summary }
   return summary.replace(revertRe, '').replace(/"$/, '')
 }
 
-
-module.exports.isRevert     = isRevert
+module.exports.isRevert = isRevert
 module.exports.cleanSummary = cleanSummary

--- a/test.js
+++ b/test.js
@@ -1,3 +1,6 @@
+// NOTE: to run this you will probably need to be authorized with GitHub.
+// Run `./changelog-maker.js` by itself to set this up.
+
 const test = require('tape')
 const execSync = require('child_process').execSync
 
@@ -9,11 +12,81 @@ function exec (args) {
 
 test('test basic commit block', function (t) {
   t.equal(exec('--start-ref=v1.3.9 --end-ref=v1.3.10'),
-    `* [[\`e28b3f2813\`](https://github.com/rvagg/changelog-maker/commit/e28b3f2813)] - 1.3.10 (Rod Vagg)
-* [[\`ace3af943e\`](https://github.com/rvagg/changelog-maker/commit/ace3af943e)] - Merge pull request #13 from jamsyoung/private-repo-support (Rod Vagg)
-* [[\`25ec5428bc\`](https://github.com/rvagg/changelog-maker/commit/25ec5428bc)] - default to repo scope always - revert previous changes (James Young)
-* [[\`424d6c22c1\`](https://github.com/rvagg/changelog-maker/commit/424d6c22c1)] - add --private arg to set repo scope, update readme (James Young)
-* [[\`7c8c5e6215\`](https://github.com/rvagg/changelog-maker/commit/7c8c5e6215)] - 1.3.9 (Rod Vagg)
+    `* [[\`e28b3f2813\`](https://github.com/nodejs/changelog-maker/commit/e28b3f2813)] - 1.3.10 (Rod Vagg)
+* [[\`ace3af943e\`](https://github.com/nodejs/changelog-maker/commit/ace3af943e)] - Merge pull request #13 from jamsyoung/private-repo-support (Rod Vagg)
+* [[\`25ec5428bc\`](https://github.com/nodejs/changelog-maker/commit/25ec5428bc)] - default to repo scope always - revert previous changes (James Young)
+* [[\`424d6c22c1\`](https://github.com/nodejs/changelog-maker/commit/424d6c22c1)] - add --private arg to set repo scope, update readme (James Young)
+* [[\`7c8c5e6215\`](https://github.com/nodejs/changelog-maker/commit/7c8c5e6215)] - 1.3.9 (Rod Vagg)
+`)
+  t.end()
+})
+
+test('test filter-release', function (t) {
+  t.equal(exec('--start-ref=v1.3.9 --end-ref=v1.3.10 --filter-release'),
+    `* [[\`ace3af943e\`](https://github.com/nodejs/changelog-maker/commit/ace3af943e)] - Merge pull request #13 from jamsyoung/private-repo-support (Rod Vagg)
+* [[\`25ec5428bc\`](https://github.com/nodejs/changelog-maker/commit/25ec5428bc)] - default to repo scope always - revert previous changes (James Young)
+* [[\`424d6c22c1\`](https://github.com/nodejs/changelog-maker/commit/424d6c22c1)] - add --private arg to set repo scope, update readme (James Young)
+`)
+  t.end()
+})
+
+test('test simple', function (t) {
+  t.equal(exec('--start-ref=v1.3.9 --end-ref=v1.3.10 --simple'),
+    `* [e28b3f2813] - 1.3.10 (Rod Vagg)
+* [ace3af943e] - Merge pull request #13 from jamsyoung/private-repo-support (Rod Vagg)
+* [25ec5428bc] - default to repo scope always - revert previous changes (James Young)
+* [424d6c22c1] - add --private arg to set repo scope, update readme (James Young)
+* [7c8c5e6215] - 1.3.9 (Rod Vagg)
+`)
+  t.end()
+})
+
+// TODO: replace HEAD with last commit for TODAY
+test('test group, semver labels, PR-URL', function (t) {
+  t.equal(exec('--start-ref=v2.2.7 --end-ref=HEAD --group --filter-release --simple'),
+    `* [cc442b6534] - (SEMVER-MINOR) minor nit (Rod Vagg) https://github.com/nodejs/node/pull/23715
+* [4f2b7f8136] - deps: use strip-ansi instead of chalk.stripColor (Rod Vagg)
+* [6898501e18] - deps: update deps, introduce test & lint deps (Rod Vagg)
+* [3e367bd67c] - feature: refactor and improve --commit-url (Rod Vagg)
+* [5094524655] - feature: make the commit url configurable via an additional argument (Jim Nielsen) https://github.com/nodejs/changelog-maker/pull/55
+* [42f248cf89] - src: use \`standard\` for linting (Rod Vagg)
+* [64a8fdef3c] - test: basic test infrastructure (Rod Vagg)
+`)
+  t.end()
+})
+
+// TODO: replace HEAD with last commit for TODAY
+test('test simple group, semver labels, PR-URL', function (t) {
+  t.equal(exec('--start-ref=v2.2.7 --end-ref=HEAD --group --filter-release'),
+    `* [[\`cc442b6534\`](https://github.com/nodejs/changelog-maker/commit/cc442b6534)] - **(SEMVER-MINOR)** minor nit (Rod Vagg) [nodejs/node#23715](https://github.com/nodejs/node/pull/23715)
+* [[\`4f2b7f8136\`](https://github.com/nodejs/changelog-maker/commit/4f2b7f8136)] - **deps**: use strip-ansi instead of chalk.stripColor (Rod Vagg)
+* [[\`6898501e18\`](https://github.com/nodejs/changelog-maker/commit/6898501e18)] - **deps**: update deps, introduce test & lint deps (Rod Vagg)
+* [[\`3e367bd67c\`](https://github.com/nodejs/changelog-maker/commit/3e367bd67c)] - **feature**: refactor and improve --commit-url (Rod Vagg)
+* [[\`5094524655\`](https://github.com/nodejs/changelog-maker/commit/5094524655)] - **feature**: make the commit url configurable via an additional argument (Jim Nielsen) [#55](https://github.com/nodejs/changelog-maker/pull/55)
+* [[\`42f248cf89\`](https://github.com/nodejs/changelog-maker/commit/42f248cf89)] - **src**: use \`standard\` for linting (Rod Vagg)
+* [[\`64a8fdef3c\`](https://github.com/nodejs/changelog-maker/commit/64a8fdef3c)] - **test**: basic test infrastructure (Rod Vagg)
+`)
+  t.end()
+})
+
+test('test blank commit-url', function (t) {
+  let actual = exec('--start-ref=v2.2.7 --end-ref=HEAD --filter-release --commit-url=http://foo.bar/').split('\n')
+  actual.splice(0, actual.length - 3)
+  actual = actual.join('\n')
+  t.equal(actual,
+    `* [[\`cc442b6534\`](http://foo.bar/)] - **(SEMVER-MINOR)** minor nit (Rod Vagg) [nodejs/node#23715](https://github.com/nodejs/node/pull/23715)
+* [[\`5094524655\`](http://foo.bar/)] - **feature**: make the commit url configurable via an additional argument (Jim Nielsen) [#55](https://github.com/nodejs/changelog-maker/pull/55)
+`)
+  t.end()
+})
+
+test('test blank commit-url', function (t) {
+  let actual = exec('--start-ref=v2.2.7 --end-ref=HEAD --filter-release --commit-url=https://yeehaw.com/{ref}/{ref}/{ghUser}/{ghRepo}/').split('\n')
+  actual.splice(0, actual.length - 3)
+  actual = actual.join('\n')
+  t.equal(actual,
+    `* [[\`cc442b6534\`](https://yeehaw.com/cc442b6534/cc442b6534/nodejs/changelog-maker/)] - **(SEMVER-MINOR)** minor nit (Rod Vagg) [nodejs/node#23715](https://github.com/nodejs/node/pull/23715)
+* [[\`5094524655\`](https://yeehaw.com/5094524655/5094524655/nodejs/changelog-maker/)] - **feature**: make the commit url configurable via an additional argument (Jim Nielsen) [#55](https://github.com/nodejs/changelog-maker/pull/55)
 `)
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -1,0 +1,19 @@
+const test = require('tape')
+const execSync = require('child_process').execSync
+
+function exec (args) {
+  let stdout = execSync(`${process.execPath} ${__dirname}/changelog-maker.js ${args}`).toString()
+
+  return stdout
+}
+
+test('test basic commit block', function (t) {
+  t.equal(exec('--start-ref=v1.3.9 --end-ref=v1.3.10'),
+    `* [[\`e28b3f2813\`](https://github.com/rvagg/changelog-maker/commit/e28b3f2813)] - 1.3.10 (Rod Vagg)
+* [[\`ace3af943e\`](https://github.com/rvagg/changelog-maker/commit/ace3af943e)] - Merge pull request #13 from jamsyoung/private-repo-support (Rod Vagg)
+* [[\`25ec5428bc\`](https://github.com/rvagg/changelog-maker/commit/25ec5428bc)] - default to repo scope always - revert previous changes (James Young)
+* [[\`424d6c22c1\`](https://github.com/rvagg/changelog-maker/commit/424d6c22c1)] - add --private arg to set repo scope, update readme (James Young)
+* [[\`7c8c5e6215\`](https://github.com/rvagg/changelog-maker/commit/7c8c5e6215)] - 1.3.9 (Rod Vagg)
+`)
+  t.end()
+})


### PR DESCRIPTION
* introduced `standard`
* added basic tests, using `tape` and checking output of ./changelog-maker.js with various options
* fixed some minor problems with #55, introducing the `--commit-url` flag

I'll need to add at least one additional commit to this batch before landing since it's using the commits here for tests and `--end-ref` can't capture the end properly (it's date based so I'll be fixable tomorrow)