### PR TITLE
Add GitHub Actions CI support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Tests
+on: [push, pull_request]
+
+jobs:
+  run:
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # switch to `8` when https://github.com/actions/setup-node/issues/27 is fixed
+        node: [8.16.1, 10, 12]
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v1
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: node --version
+      - run: npm --version
+      - run: git --version
+
+      - name: Install npm dependencies
+        run: npm install
+        env:
+          CI: true
+
+      - name: Set up ghauth config (Ubuntu)
+        run: |
+          mkdir -p ~/.config/changelog-maker/
+          echo '{"user": "nodejs", "token": "'${{ secrets.GITHUB_TOKEN }}'"}' > ~/.config/changelog-maker/config.json
+        if: startsWith(matrix.os, 'ubuntu')
+
+
+      - name: Set up ghauth config (Windows)
+        run: |
+          mkdir "%LOCALAPPDATA%\changelog-maker\"
+          echo {"user": "nodejs", "token": "${{ secrets.GITHUB_TOKEN }}"} > "%LOCALAPPDATA%\changelog-maker\config.json"
+        if: startsWith(matrix.os, 'windows')
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# changelog-maker
+# changelog-maker [![Build Status](https://github.com/nodejs/changelog-maker/workflows/Tests/badge.svg)](https://github.com/nodejs/changelog-maker/actions?workflow=Tests)
 
 **A git log to CHANGELOG.md tool**
 


### PR DESCRIPTION
1. this requires #61 for the lock file addition. If you guys don't want a lockfile, I can change this to just use `npm i`
2. I don't know what exactly is required for tests to run. A token?
3. ~I also plan to add Windows testing later~ -- DONE, but I might need to drop it from here and tackle it later separately