### PR TITLE
Update gitexec to v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -876,43 +876,30 @@
       }
     },
     "gitexec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gitexec/-/gitexec-1.0.0.tgz",
-      "integrity": "sha1-rFicoxd6mUJ0Zao3sfgXF2weNCI=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gitexec/-/gitexec-2.0.1.tgz",
+      "integrity": "sha512-GH5WDye/Rewj74Rvp8RaezLcWM1ot7IQjZEA9/M/fIIsLWYAw2OBviOnJ85bUQXMSR+tfpZWtulhE+LtOqlxMA==",
       "requires": {
-        "bl": "~1.0.0"
+        "bl": "^4.0.0"
       },
       "dependencies": {
         "bl": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-          "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+          "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
           "requires": {
-            "readable-stream": "~2.0.5"
+            "readable-stream": "^3.4.0"
           }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "^4.1.1",
     "ghauth": "^3.2.1",
     "ghissues": "^1.1.3",
-    "gitexec": "^1.0.0",
+    "gitexec": "^2.0.1",
     "list-stream": "^1.0.1",
     "minimist": "^1.2.0",
     "pkg-to-id": "0.0.3",


### PR DESCRIPTION
Currently, this breaks Windows testing. More specifically this patch: https://github.com/rvagg/gitexec/commit/51ad38d5f7b84f4b543719328fb487439616a7e9

This PR is split from #61 so that we tackle the Windows issue separately.

Closes #54 
