### PR TITLE
replace bash subcommands with separate shell spawns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # switch to `8` when https://github.com/actions/setup-node/issues/27 is fixed
-        node: [8.16.1, 10, 12]
+        node: [10, 12]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "ajv": {
@@ -876,43 +876,30 @@
       }
     },
     "gitexec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gitexec/-/gitexec-1.0.0.tgz",
-      "integrity": "sha1-rFicoxd6mUJ0Zao3sfgXF2weNCI=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gitexec/-/gitexec-2.0.1.tgz",
+      "integrity": "sha512-GH5WDye/Rewj74Rvp8RaezLcWM1ot7IQjZEA9/M/fIIsLWYAw2OBviOnJ85bUQXMSR+tfpZWtulhE+LtOqlxMA==",
       "requires": {
-        "bl": "~1.0.0"
+        "bl": "^4.0.0"
       },
       "dependencies": {
         "bl": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-          "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+          "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
           "requires": {
-            "readable-stream": "~2.0.5"
+            "readable-stream": "^3.4.0"
           }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -972,9 +959,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "hyperquest": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "^4.1.1",
     "ghauth": "^3.2.1",
     "ghissues": "^1.1.3",
-    "gitexec": "^1.0.0",
+    "gitexec": "^2.0.1",
     "list-stream": "^1.0.1",
     "minimist": "^1.2.0",
     "pkg-to-id": "0.0.3",


### PR DESCRIPTION
As per discussion in #66

I need to think about this a bit more, there's likely going to be overhead for non-windows users because this replaces all Bash subcommands with separate `spawn(shell)` executions and piecing the output together to form the final `git log` command.

It also leaves this repo in a 1/2 promisified state which is a bit awkward.

But, let's see what CI does.

Closes #63, fixes #54 