### PR TITLE
package.json: specify the files to include in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
     "lint": "standard",
     "unit": "tape test.js",
     "test": "npm run lint && npm run unit"
-  }
+  },
+  "files": [
+    "*.js",
+    "!test.js"
+  ]
 }


### PR DESCRIPTION
I know @rvagg might be against this, but I personally like to only keep the required files included.

Before:

```
C:\Users\xmr\Desktop\changelog-maker>npm pack --dry
npm notice
npm notice package: changelog-maker@2.3.0
npm notice === Tarball Contents ===
npm notice 4.1kB changelog-maker.js
npm notice 1.9kB collect-commit-labels.js
npm notice 2.4kB commit-to-output.js
npm notice 488B  group-commits.js
npm notice 1.7kB groups.js
npm notice 371B  reverts.js
npm notice 5.7kB test.js
npm notice 1.1kB package.json
npm notice 1.1kB LICENSE.md
npm notice 5.8kB README.md
npm notice 1.4kB .github/workflows/test.yml
npm notice === Tarball Details ===
npm notice name:          changelog-maker
npm notice version:       2.3.0
npm notice filename:      changelog-maker-2.3.0.tgz
npm notice package size:  8.9 kB
npm notice unpacked size: 26.0 kB
npm notice shasum:        87315fb0f2c29546fa2f01ce844dc78e6726af62
npm notice integrity:     sha512-5hq5avrYaoK0h[...]N/ZJh5mx/bX2A==
npm notice total files:   11
npm notice
changelog-maker-2.3.0.tgz
```

after:

```
C:\Users\xmr\Desktop\changelog-maker>npm pack --dry
npm notice
npm notice package: changelog-maker@2.3.0
npm notice === Tarball Contents ===
npm notice 4.1kB changelog-maker.js
npm notice 1.9kB collect-commit-labels.js
npm notice 2.4kB commit-to-output.js
npm notice 488B  group-commits.js
npm notice 1.7kB groups.js
npm notice 371B  reverts.js
npm notice 1.2kB package.json
npm notice 1.1kB LICENSE.md
npm notice 5.8kB README.md
npm notice === Tarball Details ===
npm notice name:          changelog-maker
npm notice version:       2.3.0
npm notice filename:      changelog-maker-2.3.0.tgz
npm notice package size:  7.3 kB
npm notice unpacked size: 19.0 kB
npm notice shasum:        65048f4298789146464691fad43dbd6e6445c99b
npm notice integrity:     sha512-NEgoAqc26/tqQ[...]POtwVuBl0uN2Q==
npm notice total files:   9
npm notice
changelog-maker-2.3.0.tgz
```
