### PR TITLE
custom fatal() instead of throw

### DIFF
--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -105,14 +105,14 @@ function printCommits (list) {
 
 function onCommitList (err, list) {
   if (err) {
-    throw err
+    return fatal(err)
   }
 
   list = organiseCommits(list)
 
   collectCommitLabels(list, (err) => {
     if (err) {
-      throw err
+      return fatal(err)
     }
 
     if (argv.group) {
@@ -127,6 +127,11 @@ function onCommitList (err, list) {
       printCommits(list)
     }
   })
+}
+
+function fatal (err) {
+  console.error(`Fatal error: ${err.message}`)
+  process.exit(1)
 }
 
 const _startrefcmd = replace(refcmd, { ref: argv['start-ref'] || defaultRef })

--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -19,11 +19,11 @@ function collectCommitLabels (list, callback) {
   }
 
   ghauth(authOptions, (err, authData) => {
-    const cache = {}
-
     if (err) {
       return callback(err)
     }
+
+    const cache = {}
 
     const q = async.queue((commit, next) => {
       function onFetch (err, issue) {


### PR DESCRIPTION
throws get in the way of promisified libraries so we can't use them for lazy cmdline error handling.