### PR TITLE
feat: add commit-plaintext changelog formatting

### DIFF
--- a/group-commits.js
+++ b/group-commits.js
@@ -2,7 +2,7 @@
 
 const { toGroups } = require('./groups')
 
-function groupCommits (list, plaintext = false) {
+function groupCommits (list) {
   const groupList = list.reduce((groupList, commit) => {
     const group = toGroups(commit.summary) || '*'
 
@@ -14,11 +14,9 @@ function groupCommits (list, plaintext = false) {
     return groupList
   }, {})
 
-  const grouped = Object.keys(groupList).sort().reduce((p, group) => {
+  return Object.keys(groupList).sort().reduce((p, group) => {
     return p.concat(groupList[group])
   }, [])
-
-  return grouped
 }
 
 module.exports = groupCommits

--- a/group-commits.js
+++ b/group-commits.js
@@ -2,7 +2,7 @@
 
 const { toGroups } = require('./groups')
 
-function groupCommits (list) {
+function groupCommits (list, plaintext = false) {
   const groupList = list.reduce((groupList, commit) => {
     const group = toGroups(commit.summary) || '*'
 
@@ -14,9 +14,11 @@ function groupCommits (list) {
     return groupList
   }, {})
 
-  return Object.keys(groupList).sort().reduce((p, group) => {
+  const grouped = Object.keys(groupList).sort().reduce((p, group) => {
     return p.concat(groupList[group])
   }, [])
+
+  return grouped
 }
 
 module.exports = groupCommits

--- a/test.js
+++ b/test.js
@@ -44,6 +44,16 @@ test('test simple', (t) => {
   t.end()
 })
 
+test('test plaintext', (t) => {
+  t.equal(exec('--start-ref=9c700d2 --end-ref=dd937e9 --group --filter-release --plaintext'),
+    `feature:
+  * refactor and improve --commit-url (Rod Vagg)
+test:
+  * update refs for testing (Rod Vagg)
+`)
+  t.end()
+})
+
 test('test group, semver labels, PR-URL', (t) => {
   t.equal(exec('--start-ref=v2.2.7 --end-ref=9c700d29 --group --filter-release --simple'),
     `* [cc442b6534] - (SEMVER-MINOR) minor nit (Rod Vagg) https://github.com/nodejs/node/pull/23715


### PR DESCRIPTION
Refs https://github.com/nodejs/node-core-utils/pull/388.

When auto-generating the commits for the commit message itself, we want them formatted in plaintext as specified in the [releasing guide](https://github.com/nodejs/node/blob/master/doc/guides/releases.md#5-create-release-commit). This adds a new format type to `changelog-maker` - `plaintext`.

Items formatted with this new type will take the following form:

```
doc:
  * update napi_async_init documentation (Michael Dawson) https://github.com/nodejs/node/pull/33181
  * doc and test URLSearchParams discrepancy (James M Snell) https://github.com/nodejs/node/pull/33236
  * explicitly doc package.exports is breaking (Myles Borins) https://github.com/nodejs/node/pull/33074
  * fix style and grammer in buffer.md (Nikolai Vavilov) https://github.com/nodejs/node/pull/33194
http:
  * fixes memory retention issue with FreeList and HTTPParser (John Leidegren) https://github.com/nodejs/node/pull/33190
n-api:
  * add uint32 test for -1 (Gabriel Schulhof)
src:
  * use BaseObjectPtr in StreamReq::Dispose (James M Snell) https://github.com/nodejs/node/pull/33102
  * Revert "src: add test/abort build tasks (Richard Lau) https://github.com/nodejs/node/pull/33196
  * Revert "src: add aliased-buffer-overflow abort test (Richard Lau) https://github.com/nodejs/node/pull/33196
  * retrieve binding data from the context (Joyee Cheung) https://github.com/nodejs/node/pull/33139
stream:
  * make from read one at a time (Robert Nagy) https://github.com/nodejs/node/pull/33201
test:
  * add tests for options.fs in fs streams (Julian Duque) https://github.com/nodejs/node/pull/33185
```

cc @MylesBorins @rvagg 