### PR TITLE
Escape all punctuation chars in markdown output

### DIFF
--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -5,8 +5,9 @@ const reverts = require('./reverts')
 const groups = require('./groups')
 
 function cleanMarkdown (txt) {
-  // escape _~*\[]<>
-  return txt.replace(/([_~*\\[\]<>])/g, '\\$1')
+  // escape !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+  // Refs: https://spec.commonmark.org/0.29/#example-298
+  return txt.replace(/([!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~])/g, '\\$1')
 }
 
 const formatType = {


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/38522#issuecomment-831383012

Ideally we would support backtick strings in commit message (as GitHub web UI now does), but a quicker fix is to escape them for now.