### PR TITLE
feat: improve support of backtick strings

### DIFF
--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -4,9 +4,30 @@ const chalk = require('chalk')
 const reverts = require('./reverts')
 const groups = require('./groups')
 
+function cleanUnsupportedMarkdown (txt) {
+  // escape _~*\[]<>`
+  return txt.replace(/([_~*\\[\]<>`])/g, '\\$1')
+}
 function cleanMarkdown (txt) {
-  // escape _~*\[]<>
-  return txt.replace(/([_~*\\[\]<>])/g, '\\$1')
+  // Escape backticks for edge case scenarii (no code span support).
+  if (txt.includes('``') || txt.includes('\\`')) {
+    return cleanUnsupportedMarkdown(txt)
+  }
+
+  const backtickSplit = txt.split('`')
+  // If there's an odd number of backticks, give up and escape them all.
+  if (backtickSplit.length % 2 === 0) return cleanUnsupportedMarkdown(txt)
+
+  let cleanMdString = ''
+  for (let i = 0; i < backtickSplit.length; i++) {
+    const isInsideBacktickString = i % 2
+    cleanMdString += isInsideBacktickString
+      // No escaping inside a code span.
+      ? `\`${backtickSplit[i]}\``
+      // otherwise escape _~*\[]<>
+      : backtickSplit[i].replace(/([_~*\\[\]<>])/g, '\\$1')
+  }
+  return cleanMdString
 }
 
 const formatType = {

--- a/test.js
+++ b/test.js
@@ -101,3 +101,18 @@ test('test blank commit-url', (t) => {
 `)
   t.end()
 })
+
+test('test backtick strings in commit messages', (t) => {
+  t.equal(
+    exec('--start-ref=e56d8b537f --end-ref=b0dc2f30c4 --filter-release --commit-url=https://yeehaw.com/{ref}/{ref}/{ghUser}/{ghRepo}/'),
+    `* [[\`b0dc2f30c4\`](https://yeehaw.com/b0dc2f30c4/b0dc2f30c4/nodejs/changelog-maker/)] - **test**: \\\`commit\\_msg\\\` with an unescaped \\\` backtick char (Antoine du Hamel)
+* [[\`6503a67450\`](https://yeehaw.com/6503a67450/6503a67450/nodejs/changelog-maker/)] - **test**: \\\`commit\\_msg\\\` with an escaped \\\\\\\` backtick char (Antoine du Hamel)
+* [[\`7c1eedffc3\`](https://yeehaw.com/7c1eedffc3/7c1eedffc3/nodejs/changelog-maker/)] - **test**: \`commit_msg\` starting with a backtick string (Antoine du Hamel)
+* [[\`2305fbbb3b\`](https://yeehaw.com/2305fbbb3b/2305fbbb3b/nodejs/changelog-maker/)] - **test**: commit\\_msg with \\\`backtick\\\\\\\` string (Antoine du Hamel)
+* [[\`753fcf7175\`](https://yeehaw.com/753fcf7175/753fcf7175/nodejs/changelog-maker/)] - **test**: commit\\_msg with \\\`\\\`backtick \\\` string\\\`\\\` (Antoine du Hamel)
+* [[\`2ab3cda07b\`](https://yeehaw.com/2ab3cda07b/2ab3cda07b/nodejs/changelog-maker/)] - **test**: commit\\_msg with \`back_tick\` string (Antoine du Hamel)
+* [[\`e68ae3cda6\`](https://yeehaw.com/e68ae3cda6/e68ae3cda6/nodejs/changelog-maker/)] - **test**: commit\\_msg with \`backtick\` string (Antoine du Hamel)
+* [[\`e56d8b537f\`](https://yeehaw.com/e56d8b537f/e56d8b537f/nodejs/changelog-maker/)] - **feat**: improve support of backtick strings (Antoine du Hamel)
+`)
+  t.end()
+})


### PR DESCRIPTION
Alternate to https://github.com/nodejs/changelog-maker/pull/94

Only supports code span delimited with a single backtick char and gives up if it finds an edge case.

List of unsupported markdown-compliant edge cases I could think of:
```markdown
test: string ``code `span` with backticks inside`` not supported
test: string `code span ending with a backslash\\` not supported
test: string containing escaped \` `code span` not supported
`test`: message starting with a backslash not supported
```

I wasn't sure how to add tests for that, but it works from what I have tested locally.