### PR TITLE
fix: remove build step from release process

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -67,10 +67,6 @@ jobs:
         run: |
           npm install --no-progress --no-package-lock --no-save
 
-      - name: Build
-        run: |
-          npm run build
-
       - name: Install plugins
         run: |
           npm install \


### PR DESCRIPTION
very minor ooopsie, I copied this workflow from another project which has a `build` step and forgot to remove it from here since we don't have such a script (yet).