### PR TITLE
feat: --find-matching-prs for commits without PR-URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm i changelog-maker -g
 
 ## Usage
 
-**`changelog-maker [--plaintext|p] [--markdown|md] [--sha] [--group|-g] [--reverse] [--commit-url=<url/with/{ref}>] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
+**`changelog-maker [--plaintext|p] [--markdown|md] [--sha] [--group|-g] [--reverse] [--find-matching-prs] [--commit-url=<url/with/{ref}>] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
 
 `github-user` and `github-project` should point to the GitHub repository that can be used to find the `PR-URL` data if just an issue number is provided and will also impact how the PR-URL issue numbers are displayed
 
@@ -62,6 +62,7 @@ npm i changelog-maker -g
 * `--start-ref=<ref>`: use the given git `<ref>` as a starting point rather than the _last tag_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name. If you specify a `--start-ref` argument the commit log will not be pruned so that version commits and `working on <version>` commits are left in the list.
 * `--end-ref=<ref>`:   use the given git `<ref>` as a end-point rather than the _now_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name.
 * `--filter-release`:  exclude Node-style release commits from the list. e.g. "Working on v1.0.0" or "2015-10-21 Version 2.0.0" and also "npm version X" style commits containing _only_ an `x.y.z` semver designator.
+* `--find-matching-prs`: use the GitHub API to find the pull requests that match commits that don't have the `PR-URL` metadata in their message text. Without metadata, it may be necessary to also pass the org/user and repo name on the commandline (as the `github-user` and `github-project` arguments as demonstrated above, it may also be necessary to use `--find-matching-prs=true` in this case).
 * `--quiet` or `-q`:   do not print to `process.stdout`
 * `--all` or `-a`:     process all commits since beginning, instead of last tag.
 * `--help` or `-h`:    show usage and help.

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,12 @@
+import { promisify } from 'util'
+import ghauth from 'ghauth'
+
+const authOptions = {
+  configName: 'changelog-maker',
+  scopes: ['repo'],
+  noDeviceFlow: true
+}
+
+export async function auth () {
+  return await promisify(ghauth)(authOptions)
+}

--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -1,15 +1,8 @@
 'use strict'
 
-import { promisify } from 'util'
-import ghauth from 'ghauth'
+import { auth } from './auth.js'
 import ghissues from 'ghissues'
 import async from 'async'
-
-const authOptions = {
-  configName: 'changelog-maker',
-  scopes: ['repo'],
-  noDeviceFlow: true
-}
 
 export async function collectCommitLabels (list) {
   const sublist = list.filter((commit) => {
@@ -20,7 +13,7 @@ export async function collectCommitLabels (list) {
     return
   }
 
-  const authData = await promisify(ghauth)(authOptions)
+  const authData = await auth()
 
   const cache = {}
 

--- a/find-matching-prs.js
+++ b/find-matching-prs.js
@@ -1,0 +1,72 @@
+'use strict'
+
+import { auth } from './auth.js'
+import { graphql } from '@octokit/graphql'
+import async from 'async'
+
+// Query to find the first 4 pull requests that include the commit that we're
+// concerned about. We'll filter them and take the first one that was MERGED
+// as our prUrl.
+const query = `
+  query ($owner: String!, $name: String!, $commit: GitObjectID!) {
+    repository(owner: $owner, name: $name) {
+      object(oid: $commit) {
+        ... on Commit {
+          associatedPullRequests(first: 4) {
+            ... on PullRequestConnection {
+              edges {
+                node {
+                  ... on PullRequest {
+                    number
+                    url
+                    title
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+export async function findMatchingPrs (ghId, list) {
+  // only look up commits that don't have a prUrl from metadata
+  const sublist = list.filter((commit) => typeof commit.prUrl !== 'string')
+  if (!sublist.length) {
+    return
+  }
+
+  const authData = await auth()
+  const headers = { authorization: `token ${authData.token}` }
+  const cache = {}
+
+  const q = async.queue(async (commit, next) => {
+    if (commit.ghUser === 'iojs') {
+      commit.ghUser = 'nodejs' // forcibly rewrite as the GH API doesn't do it for us
+    }
+
+    // cache on commit, so we don't run the same commit twice (is this possible?)
+    cache[commit.sha] = cache[commit.sha] || (async () => {
+      try {
+        const res = await graphql(query, { owner: ghId.user, name: ghId.repo, commit: commit.sha, headers })
+        if (res.repository?.object?.associatedPullRequests?.edges?.length) {
+          const pr = res.repository.object.associatedPullRequests.edges.filter((e) => e.node?.state === 'MERGED')[0]
+          if (pr) {
+            commit.ghIssue = pr.node.number
+            commit.prUrl = pr.node.url
+          }
+        }
+      } catch (err) {
+        console.error(`Error querying GitHub to find pull request for commit: ${err}`)
+      }
+    })()
+    await cache[commit.sha]
+    next()
+  }, 15)
+
+  q.push(sublist)
+  await q.drain()
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "keywords": [],
   "preferGlobal": true,
   "dependencies": {
+    "@octokit/graphql": "^4.8.0",
     "async": "^3.2.2",
     "chalk": "^5.0.0",
     "commit-stream": "^1.1.0",

--- a/process-commits.js
+++ b/process-commits.js
@@ -5,6 +5,7 @@ import { toGroups } from './groups.js'
 import { formatMarkdown } from './format.js'
 import { supportsColor } from 'chalk'
 import { collectCommitLabels } from './collect-commit-labels.js'
+import { findMatchingPrs } from './find-matching-prs.js'
 
 function getFormat (argv) {
   if (argv.format && Object.values(formatType).includes(argv.format)) {
@@ -32,6 +33,10 @@ export async function processCommits (argv, ghId, list) {
   const quiet = argv.quiet || argv.q
   const reverse = argv.reverse
   const commitUrl = argv['commit-url'] || 'https://github.com/{ghUser}/{ghRepo}/commit/{ref}'
+
+  if (argv['find-matching-prs']) {
+    await findMatchingPrs(ghId, list)
+  }
 
   await collectCommitLabels(list)
 

--- a/test.js
+++ b/test.js
@@ -124,3 +124,11 @@ test('test markdown punctuation chars in commit message and author name', (t) =>
 `)
   t.end()
 })
+
+test('test find-matching-prs', (t) => {
+  t.equal(
+    exec('--start-ref=a059bc7ca9 --end-ref=a059bc7ca9 --find-matching-prs=true nodejs changelog-maker'),
+    `* [a059bc7ca9] - chore(deps): remove package-lock.json (#118) (Rod Vagg) https://github.com/nodejs/changelog-maker/pull/118
+`)
+  t.end()
+})


### PR DESCRIPTION
So .. I want to use `changelog-maker` for a project that doesn't use `PR-URL` metadata, and also, it really is kind of annoying to have to put that in when GitHub knows what commit belongs to what PR and we now have a useful way to query for it.

This introduces `--find-matching-prs=true` as an argument, then uses a GraphQL query to make a best guess as to what PR the commit belongs to and fills in the blanks for it. Because this is done before label collection it should also mean that we get to collect labels for commits that don't have `PR-URL` too, which is neat.

(If someone wants to go back and fix up #73 now that this introduces a GraphQL pattern so we can use it to find labels, then that might be neat too).