### PR TITLE
chore: drop 16.x and add 20.x to CI

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16.x, 18.x, lts/*, current]
+        node: [18.x, 20.x, lts/*, current]
         # not quite windows ready, halp! os: [macos-latest, ubuntu-latest, windows-latest]
         os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
In preparation for #157 which will be a breaking change, forcing the dropping of 16.x.