### PR TITLE
feat: add CVE-ID to commit-output

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -45,6 +45,8 @@ jobs:
           npm run test:ci
   release:
     name: Release
+    permissions:
+      contents: write
     needs: test
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -39,6 +39,11 @@ export const formatType = {
 
 function toStringPlaintext (data) {
   let s = ''
+  if (data.cveId) {
+    const pr = data.pr ? data.prUrl : ''
+    return ` * ${data.cveId} - ${data.summary.trim()} - ${pr}`
+  }
+
   s += (data.semver || []).length ? `(${data.semver.join(', ').toUpperCase()}) ` : ''
 
   if (data.revert) {
@@ -76,6 +81,7 @@ function toStringMarkdown (data) {
   let s = ''
   s += `* \\[[\`${data.sha.substr(0, 10)}\`](${data.shaUrl})] - `
   s += (data.semver || []).length ? `**(${data.semver.join(', ').toUpperCase()})** ` : ''
+  s += data.cveId ? `**(${data.cveId})** ` : ''
   s += data.revert ? '***Revert*** "' : ''
   s += data.group ? `**${cleanMarkdown(data.group)}**: ` : ''
   s += cleanMarkdown(data.summary)
@@ -92,7 +98,11 @@ function toStringMarkdown (data) {
 }
 
 function toStringMessageOnly (data) {
-  return `  * ${data.summary.trim()}`
+  let cveData
+  if (data.cveId) {
+    cveData = `${data.cveId} - `
+  }
+  return `  * ${cveData}${data.summary.trim()}`
 }
 
 export function commitToOutput (commit, format, ghId, commitUrl) {
@@ -110,6 +120,7 @@ export function commitToOutput (commit, format, ghId, commitUrl) {
   data.author = (commit.author && commit.author.name) || ''
   data.pr = prUrlMatch && ((prUrlMatch[1] !== `${ghId.user}/${ghId.repo}` ? prUrlMatch[1] : '') + urlHash)
   data.prUrl = prUrlMatch && commit.prUrl
+  data.cveId = commit.cveId
 
   if (format === formatType.SIMPLE) {
     return toStringSimple(data)

--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -39,9 +39,9 @@ export const formatType = {
 
 function toStringPlaintext (data) {
   let s = ''
+
   if (data.cveId) {
-    const pr = data.pr ? data.prUrl : ''
-    return ` * ${data.cveId} - ${data.summary.trim()} - ${pr}`
+    s += `(${data.cveId})`
   }
 
   s += (data.semver || []).length ? `(${data.semver.join(', ').toUpperCase()}) ` : ''
@@ -98,11 +98,7 @@ function toStringMarkdown (data) {
 }
 
 function toStringMessageOnly (data) {
-  let cveData
-  if (data.cveId) {
-    cveData = `${data.cveId} - `
-  }
-  return `  * ${cveData}${data.summary.trim()}`
+  return `  * ${data.cveId ? '(' + data.cveId + ') ' : ''}${data.summary.trim()}`
 }
 
 export function commitToOutput (commit, format, ghId, commitUrl) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@octokit/graphql": "^7.0.1",
     "async": "^3.2.4",
     "chalk": "^5.3.0",
-    "commit-stream": "^2.1.0",
+    "commit-stream": "^2.2.0",
     "debug": "^4.3.4",
     "ghauth": "^6.0.0",
     "ghissues": "^1.1.4",

--- a/test.js
+++ b/test.js
@@ -142,3 +142,12 @@ test('test find-matching-prs', (t) => {
 `)
   t.end()
 })
+
+test('test group, CVE-ID', (t) => {
+  const out = exec('--md --start-ref=43d428b3d2 --end-ref=43d428b3d2 --group --filter-release')
+  t.equal(
+    out,
+    `* \\[[\`43d428b3d2\`](https://github.com/nodejs/changelog-maker/commit/43d428b3d2)] - **(CVE-2024-22020)** **feat**: add cveId support to commmit output (RafaelGSS) [nodejs/node#55819](https://github.com/nodejs/node/pull/55819)
+`)
+  t.end()
+})


### PR DESCRIPTION
This PR changes the commit output to include CVE-ID in the output (part of automation of security releases -  fixes: https://github.com/nodejs-private/security-release/issues/38)

Output:

```
➜  node (v18.20.4) ../changelog-maker/changelog-maker.js --group --markdown --filter-release --start-ref v18.20.3 --end-ref v18.20.4                                                                                                                        ✱
* \[[`85abedf1ff`](https://github.com/nodejs/node/commit/85abedf1ff)] - **(CVE-2024-22020)** **lib,esm**: handle bypass network-import via data: (RafaelGSS) [nodejs-private/node-private#522](https://github.com/nodejs-private/node-private/pull/522)
* \[[`eccd63b865`](https://github.com/nodejs/node/commit/eccd63b865)] - **(CVE-2024-36138)** **src**: handle permissive extension on cmd check (RafaelGSS) [nodejs-private/node-private#596](https://github.com/nodejs-private/node-private/pull/596)

➜  node (v18.20.4) ../changelog-maker/changelog-maker.js --group --plaintext --filter-release --start-ref v18.20.3 --end-ref v18.20.4                                                                                                                       ✱
lib,esm:
 * CVE-2024-22020 - handle bypass network-import via data: - https://github.com/nodejs-private/node-private/pull/522
src:
 * CVE-2024-36138 - handle permissive extension on cmd check - https://github.com/nodejs-private/node-private/pull/596
 
➜  node (v18.20.4) ../changelog-maker/changelog-maker.js --group --simple --filter-release --start-ref v18.20.3 --end-ref v18.20.4
* [85abedf1ff] - lib,esm: handle bypass network-import via data: (RafaelGSS) https://github.com/nodejs-private/node-private/pull/522
* [eccd63b865] - src: handle permissive extension on cmd check (RafaelGSS) https://github.com/nodejs-private/node-private/pull/596
 
➜  node (v18.20.4) ../changelog-maker/changelog-maker.js --group --messageonly --filter-release --start-ref v18.20.3 --end-ref v18.20.4
lib,esm:
  * CVE-2024-22020 - handle bypass network-import via data:
src:
  * CVE-2024-36138 - handle permissive extension on cmd check

```

I haven't added support to `--simple` as we won't use it in the automation. We can add it later if needed.

