### PR TITLE
refactor!: replace minimist with `node:util` `parseArgs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm i changelog-maker -g
 
 ## Usage
 
-**`changelog-maker [--plaintext|p] [--markdown|md] [--sha] [--group|-g] [--reverse] [--find-matching-prs] [--commit-url=<url/with/{ref}>] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
+**`changelog-maker [--format=<format>] [--group|-g] [--reverse] [--find-matching-prs] [--commit-url=<url/with/{ref}>] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
 
 `github-user` and `github-project` should point to the GitHub repository that can be used to find the `PR-URL` data if just an issue number is provided and will also impact how the PR-URL issue numbers are displayed
 
@@ -54,17 +54,13 @@ npm i changelog-maker -g
   - `plaintext`:         a very simple form, without commit details, implies `--group`.
   - `markdown`:          a Markdown formatted from, with links and proper escaping.
   - `messageonly`:       displays the commit message only, implies `--group`
-* `--sha`:             same as `--format=sha`.
-* `--plaintext`:       same as `--format=plaintext`.
-* `--markdown`:        same as `--format=markdown`.
-* `--messageonly`:     same as `--format=messageonly`.
 * `--group`:           reorder commits so that they are listed in groups where the `xyz:` prefix of the commit message defines the group. Commits are listed in original order _within_ group.
 * `--reverse`:         reverse the order of commits when printed, does not work with `--reverse`
 * `--commit-url`:      pass in a url template which will be used to generate commit URLs for a repository not hosted in Github. `{ref}` is the placeholder that will be replaced with the commit, i.e. `--commit-url=https://gitlab.com/myUser/myRepo/commit/{ref}`
 * `--start-ref=<ref>`: use the given git `<ref>` as a starting point rather than the _last tag_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name. If you specify a `--start-ref` argument the commit log will not be pruned so that version commits and `working on <version>` commits are left in the list.
 * `--end-ref=<ref>`:   use the given git `<ref>` as a end-point rather than the _now_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name.
 * `--filter-release`:  exclude Node-style release commits from the list. e.g. "Working on v1.0.0" or "2015-10-21 Version 2.0.0" and also "npm version X" style commits containing _only_ an `x.y.z` semver designator.
-* `--find-matching-prs`: use the GitHub API to find the pull requests that match commits that don't have the `PR-URL` metadata in their message text. Without metadata, it may be necessary to also pass the org/user and repo name on the commandline (as the `github-user` and `github-project` arguments as demonstrated above, it may also be necessary to use `--find-matching-prs=true` in this case).
+* `--find-matching-prs`: use the GitHub API to find the pull requests that match commits that don't have the `PR-URL` metadata in their message text. Without metadata, it may be necessary to also pass the org/user and repo name on the commandline (as the `github-user` and `github-project` arguments as demonstrated above).
 * `--quiet` or `-q`:   do not print to `process.stdout`
 * `--all` or `-a`:     process all commits since beginning, instead of last tag.
 * `--help` or `-h`:    show usage and help.

--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -2,29 +2,43 @@
 
 import _debug from 'debug'
 import process from 'process'
-import minimist from 'minimist'
 import pkgtoId from 'pkg-to-id'
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
+import { parseArgs } from 'util'
 import { processCommits } from './process-commits.js'
 import { commitToList } from './commit-to-list.js'
 
 const debug = _debug('changelog-maker')
 
-const argv = minimist(process.argv.slice(2))
-const help = argv.h || argv.help
+const { values, positionals } = parseArgs({
+  allowPositionals: true,
+  options: {
+    all: { type: 'boolean', short: 'a' },
+    'commit-url': { type: 'string' },
+    'end-ref': { type: 'string' },
+    'filter-release': { type: 'boolean' },
+    'find-matching-prs': { type: 'boolean' },
+    format: { type: 'string' },
+    group: { type: 'boolean', short: 'g' },
+    help: { type: 'boolean', short: 'h' },
+    quiet: { type: 'boolean', short: 'q' },
+    reverse: { type: 'boolean' },
+    'start-ref': { type: 'string' }
+  }
+})
 
 const pkgFile = join(process.cwd(), 'package.json')
 const pkgData = existsSync(pkgFile) ? JSON.parse(readFileSync(pkgFile)) : {}
 const pkgId = pkgtoId(pkgData)
 
 const ghId = {
-  user: argv._[0] || pkgId.user || 'nodejs',
-  repo: argv._[1] || (pkgId.name && stripScope(pkgId.name)) || 'node'
+  user: positionals[0] || pkgId.user || 'nodejs',
+  repo: positionals[1] || (pkgId.name && stripScope(pkgId.name)) || 'node'
 }
 debug(ghId)
 
-if (help) {
+if (values.help) {
   showUsage()
   process.exit(0)
 }
@@ -44,8 +58,8 @@ function showUsage () {
 }
 
 async function run () {
-  const commitList = await commitToList(ghId, argv)
-  await processCommits(argv, ghId, commitList)
+  const commitList = await commitToList(ghId, values)
+  await processCommits(values, ghId, commitList)
 }
 
 run().catch((err) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "ghauth": "^7.0.0",
         "ghissues": "^2.0.0",
         "gitexec": "^2.0.1",
-        "minimist": "^1.2.8",
         "pkg-to-id": "^0.0.3",
         "remark-parse": "^11.0.0",
         "remark-preset-lint-node": "^5.0.0",
@@ -8783,6 +8782,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ghauth": "^7.0.0",
     "ghissues": "^2.0.0",
     "gitexec": "^2.0.1",
-    "minimist": "^1.2.8",
     "pkg-to-id": "^0.0.3",
     "remark-parse": "^11.0.0",
     "remark-preset-lint-node": "^5.0.0",

--- a/process-commits.js
+++ b/process-commits.js
@@ -8,18 +8,11 @@ import { collectCommitLabels } from './collect-commit-labels.js'
 import { findMatchingPrs } from './find-matching-prs.js'
 
 function getFormat (argv) {
-  if (argv.format && Object.values(formatType).includes(argv.format)) {
-    return argv.format
-  } else if (argv.sha) {
-    return formatType.SHA
-  } else if (argv.plaintext || argv.p) {
-    return formatType.PLAINTEXT
-  } else if (argv.markdown || argv.md) {
-    return formatType.MARKDOWN
-  } else if (argv.messageonly || argv.mo) {
-    return formatType.MESSAGEONLY
+  if (!argv.format) {
+    return formatType.SIMPLE
   }
-  return formatType.SIMPLE
+  if (!Object.values(formatType).includes(argv.format)) throw new Error(`Unknown format: ${argv.format}`)
+  return argv.format
 }
 
 async function printCommits (list) {

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ function exec (args) {
 }
 
 test('test basic commit block', (t) => {
-  t.equal(exec('--md --start-ref=v1.3.9 --end-ref=v1.3.10'),
+  t.equal(exec('--format=markdown --start-ref=v1.3.9 --end-ref=v1.3.10'),
     `* \\[[\`e28b3f2813\`](https://github.com/nodejs/changelog-maker/commit/e28b3f2813)] - 1.3.10 (Rod Vagg)
 * \\[[\`ace3af943e\`](https://github.com/nodejs/changelog-maker/commit/ace3af943e)] - Merge pull request #13 from jamsyoung/private-repo-support (Rod Vagg)
 * \\[[\`25ec5428bc\`](https://github.com/nodejs/changelog-maker/commit/25ec5428bc)] - default to repo scope always - revert previous changes (James Young)
@@ -26,7 +26,7 @@ test('test basic commit block', (t) => {
 })
 
 test('test filter-release', (t) => {
-  t.equal(exec('--md --start-ref=v1.3.9 --end-ref=v1.3.10 --filter-release'),
+  t.equal(exec('--format=markdown --start-ref=v1.3.9 --end-ref=v1.3.10 --filter-release'),
     `* \\[[\`ace3af943e\`](https://github.com/nodejs/changelog-maker/commit/ace3af943e)] - Merge pull request #13 from jamsyoung/private-repo-support (Rod Vagg)
 * \\[[\`25ec5428bc\`](https://github.com/nodejs/changelog-maker/commit/25ec5428bc)] - default to repo scope always - revert previous changes (James Young)
 * \\[[\`424d6c22c1\`](https://github.com/nodejs/changelog-maker/commit/424d6c22c1)] - add --private arg to set repo scope, update readme (James Young)
@@ -46,7 +46,7 @@ test('test simple', (t) => {
 })
 
 test('test plaintext', (t) => {
-  t.equal(exec('--start-ref=9c700d2 --end-ref=dd937e9 --group --filter-release --plaintext'),
+  t.equal(exec('--start-ref=9c700d2 --end-ref=dd937e9 --group --filter-release --format=plaintext'),
     `feature:
   * refactor and improve --commit-url (Rod Vagg)
 test:
@@ -56,7 +56,7 @@ test:
 })
 
 test('test messageonly', (t) => {
-  t.equal(exec('--start-ref=9c700d2 --end-ref=dd937e9 --group --filter-release --messageonly'),
+  t.equal(exec('--start-ref=9c700d2 --end-ref=dd937e9 --group --filter-release --format=messageonly'),
     `feature:
   * refactor and improve --commit-url
 test:
@@ -79,7 +79,7 @@ test('test group, semver labels, PR-URL', (t) => {
 })
 
 test('test simple group, semver labels, PR-URL', (t) => {
-  t.equal(exec('--md --start-ref=v2.2.7 --end-ref=9c700d29 --group --filter-release'),
+  t.equal(exec('--format=markdown --start-ref=v2.2.7 --end-ref=9c700d29 --group --filter-release'),
     `* \\[[\`cc442b6534\`](https://github.com/nodejs/changelog-maker/commit/cc442b6534)] - **(SEMVER-MINOR)** minor nit (Rod Vagg) [nodejs/node#23715](https://github.com/nodejs/node/pull/23715)
 * \\[[\`4f2b7f8136\`](https://github.com/nodejs/changelog-maker/commit/4f2b7f8136)] - **deps**: use strip-ansi instead of chalk.stripColor (Rod Vagg)
 * \\[[\`6898501e18\`](https://github.com/nodejs/changelog-maker/commit/6898501e18)] - **deps**: update deps, introduce test & lint deps (Rod Vagg)
@@ -92,7 +92,7 @@ test('test simple group, semver labels, PR-URL', (t) => {
 })
 
 test('test blank commit-url', (t) => {
-  let actual = exec('--md --start-ref=v2.2.7 --end-ref=9c700d29 --filter-release --commit-url=http://foo.bar/').split('\n')
+  let actual = exec('--format=markdown --start-ref=v2.2.7 --end-ref=9c700d29 --filter-release --commit-url=http://foo.bar/').split('\n')
   actual.splice(0, actual.length - 3)
   actual = actual.join('\n')
   t.equal(actual,
@@ -103,7 +103,7 @@ test('test blank commit-url', (t) => {
 })
 
 test('test blank commit-url', (t) => {
-  let actual = exec('--md --start-ref=v2.2.7 --end-ref=9c700d29 --filter-release --commit-url=https://yeehaw.com/{ref}/{ref}/{ghUser}/{ghRepo}/').split('\n')
+  let actual = exec('--format=markdown --start-ref=v2.2.7 --end-ref=9c700d29 --filter-release --commit-url=https://yeehaw.com/{ref}/{ref}/{ghUser}/{ghRepo}/').split('\n')
   actual.splice(0, actual.length - 3)
   actual = actual.join('\n')
   t.equal(actual,
@@ -115,7 +115,7 @@ test('test blank commit-url', (t) => {
 
 test('test backtick strings in commit messages', (t) => {
   t.equal(
-    exec('--md --start-ref=ce886b5130 --end-ref=0717fdc946 --filter-release --commit-url=https://yeehaw.com/{ref}/{ref}/{ghUser}/{ghRepo}/'),
+    exec('--format=markdown --start-ref=ce886b5130 --end-ref=0717fdc946 --filter-release --commit-url=https://yeehaw.com/{ref}/{ref}/{ghUser}/{ghRepo}/'),
     `* \\[[\`0717fdc946\`](https://yeehaw.com/0717fdc946/0717fdc946/nodejs/changelog-maker/)] - **test**: \\\`commit\\_msg\\\` with an unescaped \\\` backtick char (Antoine du Hamel)
 * \\[[\`9f1d897c88\`](https://yeehaw.com/9f1d897c88/9f1d897c88/nodejs/changelog-maker/)] - **test**: \\\`commit\\_msg\\\` with an escaped \\\\\\\` backtick char (Antoine du Hamel)
 * \\[[\`4a3154bde0\`](https://yeehaw.com/4a3154bde0/4a3154bde0/nodejs/changelog-maker/)] - **test**: \`commit_msg\` starting with a backtick string (Antoine du Hamel)
@@ -129,7 +129,7 @@ test('test backtick strings in commit messages', (t) => {
 
 test('test markdown punctuation chars in commit message and author name', (t) => {
   t.equal(
-    exec('--md --start-ref=f12fe589c4 --end-ref=f12fe589c4 --filter-release --commit-url=https://yeehaw.com/{ref}/{ref}/{ghUser}/{ghRepo}/'),
+    exec('--format=markdown --start-ref=f12fe589c4 --end-ref=f12fe589c4 --filter-release --commit-url=https://yeehaw.com/{ref}/{ref}/{ghUser}/{ghRepo}/'),
     `* \\[[\`f12fe589c4\`](https://yeehaw.com/f12fe589c4/f12fe589c4/nodejs/changelog-maker/)] - **group\\_with\\_underscore**: test commit message (Author\\_name\\_with\\_underscore)
 `)
   t.end()
@@ -137,14 +137,14 @@ test('test markdown punctuation chars in commit message and author name', (t) =>
 
 test('test find-matching-prs', (t) => {
   t.equal(
-    exec('--start-ref=a059bc7ca9 --end-ref=a059bc7ca9 --find-matching-prs=true nodejs changelog-maker'),
+    exec('--start-ref=a059bc7ca9 --end-ref=a059bc7ca9 --find-matching-prs nodejs changelog-maker'),
     `* [a059bc7ca9] - chore(deps): remove package-lock.json (Rod Vagg) https://github.com/nodejs/changelog-maker/pull/118
 `)
   t.end()
 })
 
 test('test group, CVE-ID', (t) => {
-  const out = exec('--md --start-ref=43d428b3d2 --end-ref=43d428b3d2 --group --filter-release')
+  const out = exec('--format=markdown --start-ref=43d428b3d2 --end-ref=43d428b3d2 --group --filter-release')
   t.equal(
     out,
     `* \\[[\`43d428b3d2\`](https://github.com/nodejs/changelog-maker/commit/43d428b3d2)] - **(CVE-2024-22020)** **feat**: add cveId support to commmit output (RafaelGSS) [nodejs/node#55819](https://github.com/nodejs/node/pull/55819)
@@ -154,7 +154,7 @@ test('test group, CVE-ID', (t) => {
 
 test('test conventionalcommit style', (t) => {
   // testing that we capture `foo(bar)` as a group in `foo(bar): message`, not just `foo` in `foo: message`
-  const out = exec('--md --start-ref=35b762c7 --end-ref=375e0b7d')
+  const out = exec('--format=markdown --start-ref=35b762c7 --end-ref=375e0b7d')
   t.equal(
     out,
     `* \\[[\`375e0b7d48\`](https://github.com/nodejs/changelog-maker/commit/375e0b7d48)] - **test(cc,yay)**: add test case for conventional commits (Rod Vagg)
@@ -171,7 +171,7 @@ test('test conventionalcommit style', (t) => {
 })
 
 test('test plaintext, CVE-ID', (t) => {
-  const out = exec('--start-ref=43d428b3d2 --end-ref=43d428b3d2 --group --filter-release --plaintext')
+  const out = exec('--start-ref=43d428b3d2 --end-ref=43d428b3d2 --group --filter-release --format=plaintext')
   t.equal(
     out,
     `feat:


### PR DESCRIPTION
Breaking change as this technically removes support for some EOL Node.js release lines. While we're doing breaking changes: `--sha`, `--plaintext`, `-p`, `--markdown`, `--md`, `--messageonly` and `--mo` are no longer supported, as they were silently ignored if more than one was supplied