### PR TITLE
chore(deps): replace strip-ansi with util.stripVTControlCharacters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "remark-preset-lint-node": "^5.0.0",
         "remark-stringify": "^11.0.0",
         "split2": "^4.2.0",
-        "strip-ansi": "^7.1.0",
         "unified": "^11.0.3"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "remark-preset-lint-node": "^5.0.0",
     "remark-stringify": "^11.0.0",
     "split2": "^4.2.0",
-    "strip-ansi": "^7.1.0",
     "unified": "^11.0.3"
   },
   "devDependencies": {

--- a/process-commits.js
+++ b/process-commits.js
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'node:util'
 import { commitToOutput, formatType } from './commit-to-output.js'
 import { groupCommits } from './group-commits.js'
 import { toGroups } from './groups.js'
@@ -18,7 +18,7 @@ function getFormat (argv) {
 async function printCommits (list) {
   for (let commit of list) {
     if (!supportsColor) {
-      commit = stripAnsi(commit)
+      commit = stripVTControlCharacters(commit)
     }
     process.stdout.write(`${commit}\n`)
   }
@@ -63,7 +63,7 @@ export async function processCommits (argv, ghId, list) {
     list = await Promise.all(list.map(async (commit) => {
       let output = commitToOutput(commit, format, ghId, commitUrl)
       if (format === formatType.MARKDOWN) {
-        output = stripAnsi(output)
+        output = stripVTControlCharacters(output)
         return (await formatMarkdown(output)).replace(/\n$/, '')
       }
       return output


### PR DESCRIPTION
Replace the `strip-ansi` dependency with Node.js’s built-in `util.stripVTControlCharacters()`.