### PR TITLE
refactor: replace chalk with util.styleText

### DIFF
--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk'
+import { styleText } from 'node:util'
 import { isRevert, cleanSummary as cleanRevertSummary } from './reverts.js'
 import { toGroups, cleanSummary as cleanGroupSummary } from './groups.js'
 
@@ -71,9 +71,9 @@ function toStringSimple (data) {
   s = s.trim()
 
   return (data.semver && data.semver.length)
-    ? chalk.green.bold(s)
+    ? styleText(['green', 'bold'], s)
     : (data.group === 'doc'
-        ? chalk.grey(s)
+        ? styleText('grey', s)
         : s)
 }
 
@@ -91,9 +91,9 @@ function toStringMarkdown (data) {
   s = s.trim()
 
   return (data.semver && data.semver.length)
-    ? chalk.green.bold(s)
+    ? styleText(['green', 'bold'], s)
     : (data.group === 'doc'
-        ? chalk.grey(s)
+        ? styleText('grey', s)
         : s)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@octokit/graphql": "^9.0.3",
         "async": "^3.2.4",
-        "chalk": "^6.0.0",
         "commit-stream": "^2.2.0",
         "debug": "^4.3.4",
         "ghauth": "^7.0.0",
@@ -1391,18 +1390,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
-      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/char-regex": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@octokit/graphql": "^9.0.3",
     "async": "^3.2.4",
-    "chalk": "^6.0.0",
     "commit-stream": "^2.2.0",
     "debug": "^4.3.4",
     "ghauth": "^7.0.0",

--- a/process-commits.js
+++ b/process-commits.js
@@ -1,9 +1,8 @@
-import { stripVTControlCharacters } from 'node:util'
+import { stripVTControlCharacters, styleText } from 'node:util'
 import { commitToOutput, formatType } from './commit-to-output.js'
 import { groupCommits } from './group-commits.js'
 import { toGroups } from './groups.js'
 import { formatMarkdown } from './format.js'
-import { supportsColor } from 'chalk'
 import { collectCommitLabels } from './collect-commit-labels.js'
 import { findMatchingPrs } from './find-matching-prs.js'
 
@@ -16,6 +15,7 @@ function getFormat (argv) {
 }
 
 async function printCommits (list) {
+  const supportsColor = styleText('green', 'test') !== 'test'
   for (let commit of list) {
     if (!supportsColor) {
       commit = stripVTControlCharacters(commit)

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import { dirname, join } from 'path'
 import { execSync } from 'child_process'
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import chalk from 'chalk'
+import { styleText } from 'node:util'
 
 const __dirname = dirname(new URL(import.meta.url).pathname)
 
@@ -63,7 +63,7 @@ test:
 
 test('test group, semver labels, PR-URL', () => {
   assert.equal(exec('--start-ref=v2.2.7 --end-ref=9c700d29 --group --filter-release'),
-  `${chalk.green.bold('* [cc442b6534] - (SEMVER-MINOR) minor nit (Rod Vagg) https://github.com/nodejs/node/pull/23715')}
+  `${styleText(['green', 'bold'], '* [cc442b6534] - (SEMVER-MINOR) minor nit (Rod Vagg) https://github.com/nodejs/node/pull/23715')}
 * [4f2b7f8136] - deps: use strip-ansi instead of chalk.stripColor (Rod Vagg)
 * [6898501e18] - deps: update deps, introduce test & lint deps (Rod Vagg)
 * [9c700d2910] - feature: refactor and improve --commit-url (Rod Vagg)


### PR DESCRIPTION
Replace [chalk](https://www.npmjs.com/package/chalk) with Node.js’s built-in [util.styleText()](https://nodejs.org/api/util.html#utilstyletextformat-text-options).