### PR TITLE
refactor: replace split2 with node:readline

### DIFF
--- a/commit-to-list.js
+++ b/commit-to-list.js
@@ -1,10 +1,10 @@
 import _debug from 'debug'
 import process from 'process'
-import { pipeline as _pipeline } from 'stream'
+import { createInterface } from 'node:readline'
+import { Readable, pipeline as _pipeline } from 'stream'
 import { promisify } from 'util'
 import commitStream from 'commit-stream'
 import gitexec from 'gitexec'
-import split2 from 'split2'
 import { isReleaseCommit } from './groups.js'
 
 const debug = _debug('changelog-maker')
@@ -64,7 +64,7 @@ export async function commitToList (ghId, argv) {
   let commitList = []
   await pipeline(
     gitexec.exec(process.cwd(), _gitcmd),
-    split2(),
+    (source) => Readable.from(createInterface({ input: source, crlfDelay: Infinity })),
     commitStream(ghId.user, ghId.repo),
     async function * (source) {
       for await (const commit of source) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "remark-parse": "^11.0.0",
         "remark-preset-lint-node": "^5.0.0",
         "remark-stringify": "^11.0.0",
-        "split2": "^4.2.0",
         "unified": "^11.0.3"
       },
       "bin": {
@@ -10720,15 +10719,6 @@
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
     },
     "node_modules/standard": {
       "version": "17.1.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "remark-parse": "^11.0.0",
     "remark-preset-lint-node": "^5.0.0",
     "remark-stringify": "^11.0.0",
-    "split2": "^4.2.0",
     "unified": "^11.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace [split2](https://www.npmjs.com/package/split2) with [readline.createInterface()](https://nodejs.org/api/readline.html#readlinecreateinterfaceoptions) to parse `git log` output.

Validation: lint and targeted checks for CRLF, unterminated lines, Unicode, and input errors pass